### PR TITLE
Revert "Update .gitignore to remove .meta files"

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -51,7 +51,6 @@ ExportedObj/
 *.pidb.meta
 *.pdb.meta
 *.mdb.meta
-*.meta
 
 # Unity3D generated file on crash reports
 sysinfo.txt

--- a/CHANGELOG.md.meta
+++ b/CHANGELOG.md.meta
@@ -1,0 +1,7 @@
+fileFormatVersion: 2
+guid: fcf4c838f9c58b44884462ae389c88e6
+TextScriptImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Editor.meta
+++ b/Editor.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: 113804b8b91c5c4479acaa702570ea45
+folderAsset: yes
+DefaultImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Editor/FOAnchorEditor.cs.meta
+++ b/Editor/FOAnchorEditor.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 6093986d137c54001aef024f6208a0da
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Editor/FOObjectEditor.cs.meta
+++ b/Editor/FOObjectEditor.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 1e6e70c280fd145d39df8fd6fc24fa9b
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Editor/hudmarc.FishNetFFO.Editor.asmdef.meta
+++ b/Editor/hudmarc.FishNetFFO.Editor.asmdef.meta
@@ -1,0 +1,7 @@
+fileFormatVersion: 2
+guid: 3c898f8467499a84cac98db28d43db0e
+AssemblyDefinitionImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/LICENSE.meta
+++ b/LICENSE.meta
@@ -1,0 +1,7 @@
+fileFormatVersion: 2
+guid: fd2e50613c04f214eb0dd8a1f2a64875
+DefaultImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/README.md.meta
+++ b/README.md.meta
@@ -1,0 +1,7 @@
+fileFormatVersion: 2
+guid: 51ef42ce19b82d64882f34ef19e10ba4
+TextScriptImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Runtime.meta
+++ b/Runtime.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: 5798481b1956a53438905aa6a8856c1a
+folderAsset: yes
+DefaultImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Runtime/Example.meta
+++ b/Runtime/Example.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: a0100c480f11d3d498974274dedabb43
+folderAsset: yes
+DefaultImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Runtime/Example/FOObserverDebugger.cs.meta
+++ b/Runtime/Example/FOObserverDebugger.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: d3727e63c0bcfc64083da701ae9b1410
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Runtime/Example/FishNet.FloatingOrigin.Example.asmdef.meta
+++ b/Runtime/Example/FishNet.FloatingOrigin.Example.asmdef.meta
@@ -1,0 +1,7 @@
+fileFormatVersion: 2
+guid: 703f16cf31454d94d98acd0077986133
+AssemblyDefinitionImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Runtime/Example/Floating Origin Condition.asset.meta
+++ b/Runtime/Example/Floating Origin Condition.asset.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: 5dd18c7e6d7bf9a42b3b64e46f6ed2df
+NativeFormatImporter:
+  externalObjects: {}
+  mainObjectFileID: 11400000
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Runtime/Example/Offsetter.cs.meta
+++ b/Runtime/Example/Offsetter.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 73f0fab021080784c8185bf3a5de3a01
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Runtime/Example/TestingSetup.unitypackage.meta
+++ b/Runtime/Example/TestingSetup.unitypackage.meta
@@ -1,0 +1,7 @@
+fileFormatVersion: 2
+guid: 6196fe73315b54b308cdbd9aa56d0a49
+DefaultImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Runtime/FOAnchor.cs.meta
+++ b/Runtime/FOAnchor.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 8d08d44d566454754bb5036a1de35096
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Runtime/FOCondition.cs.meta
+++ b/Runtime/FOCondition.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: d549bf2ae887b7f4f9d1f634f7f588a3
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Runtime/FOManager.Debugging.cs.meta
+++ b/Runtime/FOManager.Debugging.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 3868b3d8b23334185a583443f6b310c9
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Runtime/FOManager.Functions.cs.meta
+++ b/Runtime/FOManager.Functions.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 9609dc7be8cd9a14db19e10cbacd1032
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Runtime/FOManager.Networking.cs.meta
+++ b/Runtime/FOManager.Networking.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 5018fb38a79c7ca4fb12f90ba778ed5b
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Runtime/FOManager.cs.meta
+++ b/Runtime/FOManager.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 006f1497cd5a810488791018cdc0d8c1
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Runtime/FOObject.cs.meta
+++ b/Runtime/FOObject.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 6be4fb6b4446c43689ab75a6a8b9bc41
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Runtime/FOSubscene.cs.meta
+++ b/Runtime/FOSubscene.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 98bf80039cf694096a560f0a88c92dc9
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Runtime/FOTypes.cs.meta
+++ b/Runtime/FOTypes.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 415fd1851f419ac4d8f1a1eabb126a87
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Runtime/FOView.cs.meta
+++ b/Runtime/FOView.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 87af6b90a67defe42ab26845ec01e02e
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Runtime/Functions.cs.meta
+++ b/Runtime/Functions.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 74537b43dac024479b8bdb74132fba2d
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Runtime/HashGrid3d.cs.meta
+++ b/Runtime/HashGrid3d.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 24a53c1f9fb5044e6a5e3a9218435490
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Runtime/IRealTransform.cs.meta
+++ b/Runtime/IRealTransform.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: a3ce0d2747529476ea1b5e423916e09e
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Runtime/Vector3d.meta
+++ b/Runtime/Vector3d.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: 61c2645d980b28c4999f576607430944
+folderAsset: yes
+DefaultImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Runtime/Vector3d/LICENSE.meta
+++ b/Runtime/Vector3d/LICENSE.meta
@@ -1,0 +1,7 @@
+fileFormatVersion: 2
+guid: 3cfdcd982db49724dbf2bb57c27b6e8b
+DefaultImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Runtime/Vector3d/Mathd.cs.meta
+++ b/Runtime/Vector3d/Mathd.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 3a862cecf63452a4d921602a7de98ec2
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Runtime/Vector3d/README.md.meta
+++ b/Runtime/Vector3d/README.md.meta
@@ -1,0 +1,7 @@
+fileFormatVersion: 2
+guid: 2fdbb7402a7b9e643b35fe68b29200bc
+TextScriptImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Runtime/Vector3d/Vector2d.cs.meta
+++ b/Runtime/Vector3d/Vector2d.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: f589903a19d00c941b930b7804996815
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Runtime/Vector3d/Vector3d.cs.meta
+++ b/Runtime/Vector3d/Vector3d.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 249c70f0e24d97248b0040d9936cb7f0
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Runtime/hudmarc.FishNetFFO.asmdef.meta
+++ b/Runtime/hudmarc.FishNetFFO.asmdef.meta
@@ -1,0 +1,7 @@
+fileFormatVersion: 2
+guid: 76e6323f644e6164591e7b26dbd00722
+AssemblyDefinitionImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Tests.meta
+++ b/Tests.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: 2bae2b10c545c4e9884ad40753c63e32
+folderAsset: yes
+DefaultImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Tests/Editor.meta
+++ b/Tests/Editor.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: 61f7195b69f3b42209fd44314c93dd1a
+folderAsset: yes
+DefaultImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Tests/Editor/Functional.cs.meta
+++ b/Tests/Editor/Functional.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 080cc2fb223bc49daa82e408339cd769
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Tests/Editor/Modules.cs.meta
+++ b/Tests/Editor/Modules.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 84cb0c806330147dfabf6ff4e3c76350
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Tests/Editor/Tests.fishnet-floating-origin_Tests.asmdef.meta
+++ b/Tests/Editor/Tests.fishnet-floating-origin_Tests.asmdef.meta
@@ -1,0 +1,7 @@
+fileFormatVersion: 2
+guid: 122a578be6dce4e8a8e6813d4c9e04d8
+AssemblyDefinitionImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Tests/Runtime.meta
+++ b/Tests/Runtime.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: 20c589d034d7448f794bd1fe18154929
+folderAsset: yes
+DefaultImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Tests/Runtime/ServersideTester.cs.meta
+++ b/Tests/Runtime/ServersideTester.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 3a136771bf2dc42c891407329ac5ec57
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Tests/Runtime/ServersideTesterAuto.cs.meta
+++ b/Tests/Runtime/ServersideTesterAuto.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 4d5169e8cd6ef464a84d862ec9b5fac6
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Tests/Runtime/hudmarc.FFO.Tests.asmdef.meta
+++ b/Tests/Runtime/hudmarc.FFO.Tests.asmdef.meta
@@ -1,0 +1,7 @@
+fileFormatVersion: 2
+guid: f3bff8d409e324898a3ff933ff1a8e98
+AssemblyDefinitionImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/package.json.meta
+++ b/package.json.meta
@@ -1,0 +1,7 @@
+fileFormatVersion: 2
+guid: 8905f740be95c8d449f35e5f35484f18
+PackageManifestImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 


### PR DESCRIPTION
Reverts hudmarc/FFO-FishNet-Floating-Origin#9

I did more testing, unfortunately we have to keep the meta files intact. Otherwise this breaks script linking: anyone who updates the package or any new user will have every script on every object on every scene go missing.